### PR TITLE
Improve Back / Forward behavior

### DIFF
--- a/extendedgestures@mpiannucci.github.com/extension.js
+++ b/extendedgestures@mpiannucci.github.com/extension.js
@@ -178,10 +178,10 @@ const TouchpadGestureAction = new Lang.Class({
                 this._switchWorkspace(sender, Meta.MotionDirection.DOWN);
                 break;
             case 8:
-                this._sendKeyEvent(Clutter.KEY_Alt_L, Clutter.KEY_Right);
+                this._sendKeyEvent(Clutter.KEY_Forward);
                 break;
             case 9:
-                this._sendKeyEvent(Clutter.KEY_Alt_L, Clutter.KEY_Left);
+                this._sendKeyEvent(Clutter.KEY_Back);
                 break;
             case 10:
                 let selector = Main.overview.viewSelector;


### PR DESCRIPTION
Instead of biding Back and Forward behavior to `Alt+Left` and `Alt+Right`, bind it to virtual `Back` and `Forward` keys.

This improves usability on several programs with different keybindings. e.g. [Notion Desktop for Linux](https://github.com/davidbailey00/notion-linux) which binds `Alt+[` and `Alt+]`.